### PR TITLE
Guard ChunkedWriteHandler.doFlush() against re-entrant invocation from user code

### DIFF
--- a/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
@@ -74,6 +74,8 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
 
     private Queue<PendingWrite> queue;
     private volatile ChannelHandlerContext ctx;
+    private boolean inFlush;
+    private boolean flushPending;
 
     public ChunkedWriteHandler() {
     }
@@ -205,6 +207,31 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
     }
 
     private void doFlush(final ChannelHandlerContext ctx) {
+        if (inFlush) {
+            // doFlush() must not re-enter itself: ChunkedInput.readChunk(...) and isEndOfInput() run
+            // between queue.peek() and queue.remove(), and user code executed there may
+            // synchronously trigger flush(), resumeTransfer(), channelInactive(...) or
+            // channelWritabilityChanged(...) on this very handler. A nested doFlush() would peek
+            // and consume the same queue entry again, which made the outer invocation fail with
+            // NoSuchElementException and let both invocations read from the same (already closed)
+            // input. Remember the nested call instead: the outer invocation re-runs the drain
+            // loop before returning, so a resumeTransfer(...) that arrives while it is about to
+            // suspend is not lost (see the old lock-based guard and its flushRequired follow-up).
+            flushPending = true;
+            return;
+        }
+        inFlush = true;
+        try {
+            do {
+                flushPending = false;
+                doFlush0(ctx);
+            } while (flushPending);
+        } finally {
+            inFlush = false;
+        }
+    }
+
+    private void doFlush0(final ChannelHandlerContext ctx) {
         final Channel channel = ctx.channel();
         if (!channel.isActive()) {
             // Even after discarding all previous queued objects we should propagate the flush through

--- a/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
@@ -18,6 +18,7 @@ package io.netty.handler.stream;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -824,6 +825,180 @@ public class ChunkedWriteHandlerTest {
 
         boolean isClosed() {
             return closed;
+        }
+    }
+
+    @Test
+    public void testResumeTransferReenteredFromReadChunkMustNotBeLostWhenSuspending() {
+        final ChunkedWriteHandler streamer = new ChunkedWriteHandler();
+        final EmbeddedChannel ch = new EmbeddedChannel(streamer);
+        SuspendResumeChunkedInput input = new SuspendResumeChunkedInput(streamer);
+        ChannelFuture future = ch.write(input);
+        ch.flush();
+
+        // The input suspends (first readChunk(...) returns null) after its implementation has
+        // already produced data and synchronously called resumeTransfer() from within
+        // readChunk(...). A plain re-entrancy guard would drop that nested call and leave the
+        // transfer suspended forever; the guard must re-run the drain loop instead.
+        ByteBuf chunk = ch.readOutbound();
+        assertNull(ch.readOutbound());
+        assertFalse(ch.finishAndReleaseAll());
+
+        assertEquals(42, chunk.readInt());
+        chunk.release();
+        assertEquals(2, input.readChunkCalls());
+        assertTrue(input.isClosed());
+        assertTrue(future.isSuccess());
+    }
+
+    private static final class SuspendResumeChunkedInput implements ChunkedInput<ByteBuf> {
+        private final ChunkedWriteHandler streamer;
+        private final AtomicInteger readChunkCalls = new AtomicInteger();
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        SuspendResumeChunkedInput(ChunkedWriteHandler streamer) {
+            this.streamer = streamer;
+        }
+
+        int readChunkCalls() {
+            return readChunkCalls.get();
+        }
+
+        boolean isClosed() {
+            return closed.get();
+        }
+
+        @Override
+        public boolean isEndOfInput() {
+            return readChunkCalls.get() >= 2;
+        }
+
+        @Override
+        public void close() {
+            closed.set(true);
+        }
+
+        @Override
+        public ByteBuf readChunk(ChannelHandlerContext ctx) throws Exception {
+            return readChunk(ctx.alloc());
+        }
+
+        @Override
+        public ByteBuf readChunk(ByteBufAllocator allocator) throws Exception {
+            if (readChunkCalls.incrementAndGet() == 1) {
+                // Data becomes available "now", so the producer resumes synchronously, but this
+                // call still reports "no chunk yet": doFlush(...) is about to suspend when the
+                // nested resumeTransfer() arrives, and that call must not be dropped.
+                streamer.resumeTransfer();
+                return null;
+            }
+            ByteBuf buffer = allocator.buffer(4);
+            buffer.writeInt(42);
+            return buffer;
+        }
+
+        @Override
+        public long length() {
+            return -1;
+        }
+
+        @Override
+        public long progress() {
+            return 0;
+        }
+    }
+
+    @Test
+    public void testFlushReenteredFromReadChunkMustNotConsumeQueueEntryTwice() {
+        final EmbeddedChannel ch = new EmbeddedChannel(new ChunkedWriteHandler());
+        ReentrantFlushChunkedInput input = new ReentrantFlushChunkedInput(ch);
+        ChannelFuture future = ch.write(input);
+        ch.flush();
+
+        ByteBuf first = ch.readOutbound();
+        ByteBuf second = ch.readOutbound();
+        assertNull(ch.readOutbound());
+        // Before the re-entrancy guard, the nested flush() consumed the queue entry and both
+        // invocations read from the same input; the outer doFlush(...) then failed with
+        // NoSuchElementException from ArrayDeque.remove() on the already-empty queue.
+        // Both chunks were read above, so no message must be left in the buffers.
+        assertFalse(ch.finishAndReleaseAll());
+
+        assertEquals(1, first.readInt());
+        first.release();
+        assertEquals(2, second.readInt());
+        second.release();
+        // The input must have been read exactly twice, and closed exactly once, after the last
+        // read: before the guard, close() happened from the nested invocation while the outer
+        // readChunk(...) call had not even returned yet.
+        assertEquals(2, input.readChunkCalls());
+        assertTrue(input.isClosed());
+        assertEquals(2, input.readChunkCallsAtClose());
+        assertTrue(future.isSuccess());
+    }
+
+    private static final class ReentrantFlushChunkedInput implements ChunkedInput<ByteBuf> {
+        private final Channel channel;
+        private final AtomicInteger readChunkCalls = new AtomicInteger();
+        private final AtomicInteger readChunkCallsAtClose = new AtomicInteger(-1);
+        private final AtomicBoolean closed = new AtomicBoolean();
+        private int chunkNo;
+
+        ReentrantFlushChunkedInput(Channel channel) {
+            this.channel = channel;
+        }
+
+        int readChunkCalls() {
+            return readChunkCalls.get();
+        }
+
+        int readChunkCallsAtClose() {
+            return readChunkCallsAtClose.get();
+        }
+
+        boolean isClosed() {
+            return closed.get();
+        }
+
+        @Override
+        public boolean isEndOfInput() {
+            return chunkNo >= 2;
+        }
+
+        @Override
+        public void close() {
+            closed.set(true);
+            readChunkCallsAtClose.set(readChunkCalls.get());
+        }
+
+        @Override
+        public ByteBuf readChunk(ChannelHandlerContext ctx) throws Exception {
+            return readChunk(ctx.alloc());
+        }
+
+        @Override
+        public ByteBuf readChunk(ByteBufAllocator allocator) throws Exception {
+            int call = readChunkCalls.incrementAndGet();
+            if (call == 1) {
+                // Runs between queue.peek() and queue.remove() in doFlush(...). Re-enter the
+                // handler synchronously, like incidental pipeline activity triggered from user
+                // code (a flush, a writability change, a close notification) would.
+                channel.flush();
+            }
+            chunkNo++;
+            ByteBuf buffer = allocator.buffer(4);
+            buffer.writeInt(chunkNo);
+            return buffer;
+        }
+
+        @Override
+        public long length() {
+            return -1;
+        }
+
+        @Override
+        public long progress() {
+            return 0;
         }
     }
 }


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## Motivation

`ChunkedWriteHandler.doFlush(...)` intermittently fails with `NoSuchElementException` from `ArrayDeque.remove()` (#14839).

Root cause: `queue.peek()` and the `queue.remove()` calls are separated by user code. `ChunkedInput.readChunk(...)` and `isEndOfInput()` run between them, and that user code can synchronously re-enter the handler — an incidental `flush()`, a `resumeTransfer()`, a writability change, or a close notification. The nested `doFlush(...)` peeks and consumes the *same* queue entry:

1. the outer invocation then calls `queue.remove()` on an already-empty queue → `NoSuchElementException`,
2. both invocations read from the same input — including after the nested one closed it,
3. the double consumption leaks a chunk buffer (caught by leak detection in the regression test).

A deterministic reproducer on 4.1.119 matches the stack reported on 4.1.118 frame by frame (`doFlush:287`, `flush:146`).

## Modification

1. Guard `doFlush(...)` against re-entrant invocation: an `inFlush` flag, cleared in `finally` — same shape as the re-entrancy guard added to `Http2ConnectionHandler.flush(...)` in #17266.
2. A nested call is remembered (`flushPending`), not dropped: the outer invocation re-runs the drain loop before returning. A plain `return` guard would lose a `resumeTransfer(...)` that arrives while the transfer is about to suspend — the same lost-resume problem the old lock-based guard addressed with `flushRequired` (#637).
3. Two regression tests in `ChunkedWriteHandlerTest`:
   - re-entrant `flush()` from `readChunk(...)`: fails on master with the reported `NoSuchElementException` and a leak-detection error, passes with the guard; asserts the input is read exactly twice, closed exactly once after the last read, both chunks written once in order, and the promise succeeds,
   - `resumeTransfer()` from a suspending `readChunk(...)`: passes on master (where the nested call does the work but the outer `NoSuchElementException` is not surfaced to the caller) and on the guard, fails on a plain-`return` variant of the guard (transfer hangs) — it pins the no-lost-resume property.

## Result

Fixes #14839.
